### PR TITLE
Add a callback after an update is applied to a y-doc, and pass the update in the callback

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -77,13 +77,13 @@ export const readSyncStep1 = (decoder, encoder, doc) =>
  * @param {decoding.Decoder} decoder
  * @param {Y.Doc} doc
  * @param {any} transactionOrigin
- * @param {(update: Uint8Array) => void} [onApplyUpdate=(update) => {}]
+ * @param {(update: Uint8Array) => void} [onApplyUpdate = (update) => {}]
  */
-export const readSyncStep2 = (decoder, doc, transactionOrigin, onApplyUpdate=((update) => {})) => {
+export const readSyncStep2 = (decoder, doc, transactionOrigin, onApplyUpdate = ((update) => {})) => {
   try {
-    const update = decoding.readVarUint8Array(decoder);
+    const update = decoding.readVarUint8Array(decoder)
     Y.applyUpdate(doc, update, transactionOrigin)
-    onApplyUpdate(update);
+    onApplyUpdate(update)
   } catch (error) {
     // This catches errors that are thrown by event handlers
     console.error('Caught error while handling a Yjs update', error)
@@ -105,7 +105,7 @@ export const writeUpdate = (encoder, update) => {
  * @param {decoding.Decoder} decoder
  * @param {Y.Doc} doc
  * @param {any} transactionOrigin
- * @param {(update: Uint8Array) => void} [onApplyUpdate=(update) => {}]
+ * @param {(update: Uint8Array) => void} [onApplyUpdate = (update) => {}]
  */
 export const readUpdate = readSyncStep2
 
@@ -114,9 +114,9 @@ export const readUpdate = readSyncStep2
  * @param {encoding.Encoder} encoder The reply message. Will not be sent if empty.
  * @param {Y.Doc} doc
  * @param {any} transactionOrigin
- * @param {(update: Uint8Array) => void} [onApplyUpdate=(update) => {}]
+ * @param {(update: Uint8Array) => void} [onApplyUpdate = (update) => {}]
  */
-export const readSyncMessage = (decoder, encoder, doc, transactionOrigin, onApplyUpdate=((update) => {})) => {
+export const readSyncMessage = (decoder, encoder, doc, transactionOrigin, onApplyUpdate = ((update) => {})) => {
   const messageType = decoding.readVarUint(decoder)
   switch (messageType) {
     case messageYjsSyncStep1:


### PR DESCRIPTION
Isolating the update that is received by a horizontally-scalable websocket-server from a client is essential for:

1. persisting updates to y-doc - as different clients will send different updates, and only the updates that are sent by clients need to be persisted for having the ability to initialize a y-doc for a new client from the database
2. broadcasting the update using pub-sub - as different websocket processes will receive different updates from the clients connected to them, broadcasting the incoming update is essentially how different y-docs held in memory by different websocket-servers can be kept in sync (and thus, the different clients can be kept in sync)

Having the callback added in this PR basically makes 1 & 2 possible without having the need to repeat some parts of what y-js does internally in project-specific code in order to isolate the to-be-applied update