### PR TITLE
Add type definitions to exports in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,18 +47,21 @@
     "./sync.js": "./sync.js",
     "./dist/sync.cjs": "./dist/sync.cjs",
     "./sync": {
+      "types": "./sync.d.ts",
       "import": "./sync.js",
       "require": "./dist/sync.cjs"
     },
     "./awareness.js": "./awareness.js",
     "./dist/awareness.cjs": "./dist/awareness.cjs",
     "./awareness": {
+      "types": "./awareness.d.ts",
       "import": "./awareness.js",
       "require": "./dist/awareness.cjs"
     },
     "./auth.js": "./auth.js",
     "./dist/auth.cjs": "./dist/auth.cjs",
     "./auth": {
+      "types": "./auth.d.ts",
       "import": "./auth.js",
       "require": "./dist/auth.cjs"
     }


### PR DESCRIPTION
The package doesn't explicitly export the generated typescript definitions.
This PR adds the type definition files to the exports in the package.json

I hope to solve this problem with that :sweat_smile: 

```
src/y-doc-message-transporter.test.ts:11:27 - error TS7016: Could not find a declaration file for module 'y-protocols/awareness'. '[...]/node_modules/y-protocols/dist/awareness.cjs' implicitly has an 'any' type.
  Try `npm i --save-dev @types/y-protocols` if it exists or add a new declaration (.d.ts) file containing `declare module 'y-protocols/awareness';`
```