### PR TITLE
Update sync.js

### DIFF
--- a/sync.js
+++ b/sync.js
@@ -107,7 +107,7 @@ export const readUpdate = readSyncStep2
 
 /**
  * @param {decoding.Decoder} decoder A message received from another client
- * @param {encoding.Encoder} encoder The reply message. Will not be sent if empty.
+ * @param {encoding.Encoder} encoder The reply message. Does not need to be sent if empty.
  * @param {Y.Doc} doc
  * @param {any} transactionOrigin
  */


### PR DESCRIPTION
Updated the comment. As it was written, it felt as if this library performed the actual sending of the message contained in `encoder`. However, this library is network agnostic. 

Rather, it seems, it's up to the server using this lib whether it wants to send the message or not, and should not send it if it detects the message is empty (as seen [here](https://github.com/yjs/y-websocket/blob/625a9d52ba8bcff90a941d51ae151869e220f368/bin/utils.js#L171)).