### PR TITLE
Allow a consumer to switch between JSON and binary encoding for awareness

### DIFF
--- a/awareness.js
+++ b/awareness.js
@@ -156,6 +156,11 @@ export class Awareness extends Observable {
   }
 }
 
+/**
+ * A state encoder that serializes state into JSON.
+ *
+ * This is the default strategy used in this package.
+ */
 export class DefaultAwarenessStateEncoder {
   /**
    * Encode an awareness state entry
@@ -176,6 +181,9 @@ export class DefaultAwarenessStateEncoder {
   }
 }
 
+/**
+ * A state encoder that serializes state into a binary format.
+ */
 export class BinaryAwarenessStateEncoder {
   /**
    * Encode an awareness state entry

--- a/awareness.test.js
+++ b/awareness.test.js
@@ -4,9 +4,10 @@ import * as t from 'lib0/testing'
 import * as awareness from './awareness'
 
 /**
- * @param {t.TestCase} tc
+ * @param {awareness.DefaultAwarenessStateEncoder|awareness.BinaryAwarenessStateEncoder} stateEncoder
+ * @return {function(t.TestCase): void}
  */
-export const testAwareness = tc => {
+const testAwarenessWithEncoding = (stateEncoder = new awareness.DefaultAwarenessStateEncoder()) => tc => {
   const doc1 = new Y.Doc()
   doc1.clientID = 0
   const doc2 = new Y.Doc()
@@ -14,8 +15,8 @@ export const testAwareness = tc => {
   const aw1 = new awareness.Awareness(doc1)
   const aw2 = new awareness.Awareness(doc2)
   aw1.on('update', /** @param {any} p */ ({ added, updated, removed }) => {
-    const enc = awareness.encodeAwarenessUpdate(aw1, added.concat(updated).concat(removed))
-    awareness.applyAwarenessUpdate(aw2, enc, 'custom')
+    const enc = awareness.encodeAwarenessUpdate(aw1, added.concat(updated).concat(removed), aw1.states, stateEncoder)
+    awareness.applyAwarenessUpdate(aw2, enc, 'custom', stateEncoder)
   })
   let lastChangeLocal = /** @type {any} */ (null)
   aw1.on('change', /** @param {any} change */ change => {
@@ -51,3 +52,7 @@ export const testAwareness = tc => {
   t.compare(aw1.getStates().get(0), undefined)
   t.compare(lastChangeLocal, lastChange)
 }
+
+export const testAwareness = testAwarenessWithEncoding()
+export const testAwarenessWithBinary = testAwarenessWithEncoding(new awareness.BinaryAwarenessStateEncoder())
+export const testAwarenessWithDefault = testAwarenessWithEncoding(new awareness.DefaultAwarenessStateEncoder())


### PR DESCRIPTION
This PR is intended to add support for binary awareness encoding as discussed in #26. I'd appreciate any feedback you have!

I have tested it out locally for my use case - and it appears to be working correctly in both modes.